### PR TITLE
Now uses 'global' on node 6+

### DIFF
--- a/jquery-node.js
+++ b/jquery-node.js
@@ -6,7 +6,12 @@ if (typeof define === 'function' && define.amd) {
     var jsdom = require('jsdom').jsdom,
         window = jsdom('').defaultView;
 
-    GLOBAL.document = window.document;
+    if(JSON.parse(process.version.match(/v(\d+)\.\d+\.\d+/)[1]) >= 6) {
+      global.document = window.document;
+    } else {
+      GLOBAL.document = window.document;
+    }
+
     //(document.defaultView === window) is true
 
     module.exports = require('jquery')(window);


### PR DESCRIPTION
This pull request fixes the use of the deprecated 'GLOBAL' variable on Node 6+.

Gets rid of annoying deprecation warnings such as:
(node:2272) DeprecationWarning: 'GLOBAL' is deprecated, use 'global'
